### PR TITLE
Added List and bullets and bug fixs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "xainjatt/html-to-quill",
   "type": "library",
   "description": "PHP HTML to Quill Delta converter",
-  "homepage": "https://github.com/Everyday-AS/html-to-quill",
+  "homepage": "https://github.com/XAINJATT/html-to-quill",
   "keywords": [
     "convert",
     "delta",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   ],
   "require": {
     "php": ">=7.4",
-    "everyday/php-quill-delta": "^0.1.6",
+    "xainjatt/php-quill-delta": "dev-master",
     "symfony/dom-crawler": "^v6.0.0",
     "ext-dom": "*",
     "ext-json": "*"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
+    "php": ">=7.4",
     "everyday/php-quill-delta": "^0.1.6",
     "symfony/dom-crawler": "^v6.0.0",
     "ext-dom": "*",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "everyday/html-to-quill",
+  "name": "xainjatt/html-to-quill",
   "type": "library",
   "description": "PHP HTML to Quill Delta converter",
   "homepage": "https://github.com/Everyday-AS/html-to-quill",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": ">=7.4",
     "xainjatt/php-quill-delta": "dev-master",
-    "symfony/dom-crawler": "^v6.0.0",
+    "symfony/dom-crawler": "*",
     "ext-dom": "*",
     "ext-json": "*"
   },

--- a/src/Converters/EmphasisConverter.php
+++ b/src/Converters/EmphasisConverter.php
@@ -18,6 +18,7 @@ class EmphasisConverter implements NodeConverterInterface
         match ($node->nodeName) {
             'b', 'strong' => DeltaOp::applyAttributes($ops, ['bold' => true]),
             'em', 'i' => DeltaOp::applyAttributes($ops, ['italic' => true]),
+            'u' => DeltaOp::applyAttributes($ops, ['underline' => true]),
         };
 
         return $ops;
@@ -28,6 +29,6 @@ class EmphasisConverter implements NodeConverterInterface
      */
     public function getSupportedTags(): array
     {
-        return ['strong', 'b', 'em', 'i'];
+        return ['strong', 'b', 'em', 'i', 'u'];
     }
 }

--- a/src/Converters/EmphasisConverter.php
+++ b/src/Converters/EmphasisConverter.php
@@ -21,6 +21,12 @@ class EmphasisConverter implements NodeConverterInterface
             'u' => DeltaOp::applyAttributes($ops, ['underline' => true]),
         };
 
+        if ($node->parentNode->nodeName !== "li" && !$node->hasChildNodes()) {
+            return array_merge(
+                [DeltaOp::text("\n")],
+                $ops,
+            );
+        }
         return $ops;
     }
 

--- a/src/Converters/EmphasisConverter.php
+++ b/src/Converters/EmphasisConverter.php
@@ -16,7 +16,7 @@ class EmphasisConverter implements NodeConverterInterface
         $ops = $htmlConverter->convertChildren($node);
 
         match ($node->nodeName) {
-            'b' => DeltaOp::applyAttributes($ops, ['bold' => true]),
+            'b', 'strong' => DeltaOp::applyAttributes($ops, ['bold' => true]),
             'em', 'i' => DeltaOp::applyAttributes($ops, ['italic' => true]),
         };
 
@@ -28,6 +28,6 @@ class EmphasisConverter implements NodeConverterInterface
      */
     public function getSupportedTags(): array
     {
-        return ['b', 'em', 'i'];
+        return ['strong', 'b', 'em', 'i'];
     }
 }

--- a/src/Converters/HeaderConverter.php
+++ b/src/Converters/HeaderConverter.php
@@ -18,20 +18,26 @@ class HeaderConverter implements NodeConverterInterface
         if (isset($node->attributes['align'])) {
             $modifier->setAttribute('align', $node->attributes['align']->value);
         }
-        
-        if (isset($node->attributes['class'])) {
-            $class = $node->attributes['class'];
-            $map = ['q-align-center' => 'center', 'q-align-right' => 'right', 'q-align-left' => 'left'];
-            if (isset($map[$class])) {
-                $modifier->setAttribute('align', $map[$class]);
+
+        if ($node->attributes['class']) {
+            if ($node->attributes['class']->nodeValue == "ql-align-center") {
+                $modifier->setAttribute('align', 'center');
+            } elseif ($node->attributes['class']->nodeValue == "ql-align-left") {
+                $modifier->setAttribute('align', 'left');
+            } elseif ($node->attributes['class']->nodeValue == "ql-align-right") {
+                $modifier->setAttribute('align', 'right');
             }
         }
-
-
+        
+        $ops = [];
+        if ($modifier->isBlockModifier()) {
+            $ops[] = $modifier;
+        }
         return array_merge(
             [DeltaOp::text("\n")],
             $htmlConverter->convertChildren($node),
-            [DeltaOp::blockModifier('header', (int)substr($node->nodeName, 1, 1))]
+            [DeltaOp::blockModifier('header', (int)substr($node->nodeName, 1, 1))],
+            $ops,
         );
     }
 

--- a/src/Converters/HeaderConverter.php
+++ b/src/Converters/HeaderConverter.php
@@ -18,6 +18,15 @@ class HeaderConverter implements NodeConverterInterface
         if (isset($node->attributes['align'])) {
             $modifier->setAttribute('align', $node->attributes['align']->value);
         }
+        
+        if (isset($node->attributes['class'])) {
+            $class = $node->attributes['class'];
+            $map = ['q-align-center' => 'center', 'q-align-right' => 'right', 'q-align-left' => 'left'];
+            if (isset($map[$class])) {
+                $modifier->setAttribute('align', $map[$class]);
+            }
+        }
+
 
         return array_merge(
             [DeltaOp::text("\n")],

--- a/src/Converters/ImageConverter.php
+++ b/src/Converters/ImageConverter.php
@@ -34,15 +34,15 @@ class ImageConverter implements NodeConverterInterface
         if (null !== ($align = $node->attributes->getNamedItem('align'))) {
             $ops[] = DeltaOp::blockModifier('align', $align->textContent);
         }
-
-        if (isset($node->attributes['class'])) {
-            $class = $node->attributes['class'];
-            $map = ['q-align-center' => 'center', 'q-align-right' => 'right', 'q-align-left' => 'left'];
-            if (isset($map[$class])) {
-                $ops[] = DeltaOp::blockModifier('align', $map[$class]);
+        if ($node->attributes['class']) {
+            if ($node->attributes['class']->nodeValue == "ql-align-center") {
+                $ops[] = DeltaOp::blockModifier('align', "center");
+            } elseif ($node->attributes['class']->nodeValue == "ql-align-left") {
+                $ops[] = DeltaOp::blockModifier('align', "left");
+            } elseif ($node->attributes['class']->nodeValue == "ql-align-right") {
+                $ops[] = DeltaOp::blockModifier('align', "right");
             }
         }
-
         return $ops;
     }
 

--- a/src/Converters/ImageConverter.php
+++ b/src/Converters/ImageConverter.php
@@ -43,6 +43,12 @@ class ImageConverter implements NodeConverterInterface
                 $ops[] = DeltaOp::blockModifier('align', "right");
             }
         }
+        if ($node->parentNode->nodeName !== "li") {
+            return array_merge(
+                [DeltaOp::text("\n")],
+                $ops,
+            );
+        }
         return $ops;
     }
 

--- a/src/Converters/ImageConverter.php
+++ b/src/Converters/ImageConverter.php
@@ -25,7 +25,7 @@ class ImageConverter implements NodeConverterInterface
         }
 
         $attributes = [
-            'alt' => $node->attributes->getNamedItem('alt')->textContent ?? null,
+//             'alt' => $node->attributes->getNamedItem('alt')->textContent ?? null,
             'height' => $node->attributes->getNamedItem('height')->textContent ?? null,
             'width' => $node->attributes->getNamedItem('width')->textContent ?? null,
         ];

--- a/src/Converters/ImageConverter.php
+++ b/src/Converters/ImageConverter.php
@@ -15,8 +15,7 @@ class ImageConverter implements NodeConverterInterface
     {
         $src = $node->attributes->getNamedItem('src')->textContent ?? null;
 
-        if (null === $src)
-        {
+        if (null === $src) {
             return null;
         }
 
@@ -25,7 +24,7 @@ class ImageConverter implements NodeConverterInterface
         }
 
         $attributes = [
-//             'alt' => $node->attributes->getNamedItem('alt')->textContent ?? null,
+            //             'alt' => $node->attributes->getNamedItem('alt')->textContent ?? null,
             'height' => $node->attributes->getNamedItem('height')->textContent ?? null,
             'width' => $node->attributes->getNamedItem('width')->textContent ?? null,
         ];
@@ -34,6 +33,14 @@ class ImageConverter implements NodeConverterInterface
 
         if (null !== ($align = $node->attributes->getNamedItem('align'))) {
             $ops[] = DeltaOp::blockModifier('align', $align->textContent);
+        }
+
+        if (isset($node->attributes['class'])) {
+            $class = $node->attributes['class'];
+            $map = ['q-align-center' => 'center', 'q-align-right' => 'right', 'q-align-left' => 'left'];
+            if (isset($map[$class])) {
+                $ops[] = DeltaOp::blockModifier('align', $map[$class]);
+            }
         }
 
         return $ops;

--- a/src/Converters/LinkConverter.php
+++ b/src/Converters/LinkConverter.php
@@ -25,9 +25,9 @@ class LinkConverter implements NodeConverterInterface
 
             DeltaOp::applyAttributes($ops, ['link' => $href]);
 
-            if (null !== ($target = $node->attributes->getNamedItem('target'))) {
-                DeltaOp::applyAttributes($ops, ['target' => $target->textContent]);
-            }
+//             if (null !== ($target = $node->attributes->getNamedItem('target'))) {
+//                 DeltaOp::applyAttributes($ops, ['target' => $target->textContent]);
+//             }
         }
 
         return $ops;

--- a/src/Converters/ListConverter.php
+++ b/src/Converters/ListConverter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Everyday\HtmlToQuill\Converters;
+
+use DOMNode;
+use Everyday\HtmlToQuill\HtmlConverterInterface;
+use Everyday\QuillDelta\DeltaOp;
+
+class ListConverter implements NodeConverterInterface
+{
+    public function convert(DOMNode $node, HtmlConverterInterface $htmlConverter): array
+    {
+        $ops = $htmlConverter->convertChildren($node, ['preserveWhitespace' => true]);
+
+        $attribute =  $node->nodeName == 'ul' ? 'bullet' : 'ordered';
+        $modifier = DeltaOp::text("\n");
+        // $ops[] = $modifier->setAttribute("list", $attribute);
+        foreach ($node->childNodes as $child) {
+            if ($child instanceof DOMNode) {
+                // if ($child->nodeName == "li") {
+                    $ops[] = $modifier->setAttribute("list", $attribute);
+                // }
+            }
+        }
+        if ($modifier->isBlockModifier()) {
+            $ops[] = $modifier;
+        }
+
+        return $ops;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getSupportedTags(): array
+    {
+        return ['ul', 'ol', 'li'];
+    }
+}

--- a/src/Converters/ListConverter.php
+++ b/src/Converters/ListConverter.php
@@ -10,22 +10,31 @@ class ListConverter implements NodeConverterInterface
 {
     public function convert(DOMNode $node, HtmlConverterInterface $htmlConverter): array
     {
-        $ops = $htmlConverter->convertChildren($node, ['preserveWhitespace' => true]);
+        $attribute = "\t";
+        $ops = $htmlConverter->convertChildren($node);
+        if ($node->nodeName == "li") {
+            if ($node->parentNode->nodeName == "ul") {
+                $attribute = "bullet";
+            }
+            if ($node->parentNode->nodeName == "ol") {
+                $attribute = "ordered";
+            }
+        }
 
-        $attribute =  $node->nodeName == 'ul' ? 'bullet' : 'ordered';
         $modifier = DeltaOp::text("\n");
-        // $ops[] = $modifier->setAttribute("list", $attribute);
+        $ops[] = $modifier->setAttribute("list", $attribute);
+
         foreach ($node->childNodes as $child) {
             if ($child instanceof DOMNode) {
-                // if ($child->nodeName == "li") {
+                if ($child->nodeName == "li") {
                     $ops[] = $modifier->setAttribute("list", $attribute);
-                // }
+                }
             }
         }
         if ($modifier->isBlockModifier()) {
             $ops[] = $modifier;
         }
-
+        
         return $ops;
     }
 

--- a/src/Converters/ParagraphConverter.php
+++ b/src/Converters/ParagraphConverter.php
@@ -20,12 +20,14 @@ class ParagraphConverter implements NodeConverterInterface
         if (isset($node->attributes['align'])) {
             $modifier->setAttribute('align', $node->attributes['align']->value);
         }
-        
-        if (isset($node->attributes['class'])) {
-            $class = $node->attributes['class'];
-            $map = ['q-align-center' => 'center', 'q-align-right' => 'right', 'q-align-left' => 'left'];
-            if (isset($map[$class])) {
-                $modifier->setAttribute('align', $map[$class]);
+
+        if ($node->attributes['class']) {
+            if ($node->attributes['class']->nodeValue == "ql-align-center") {
+                $modifier->setAttribute('align', 'center');
+            } elseif ($node->attributes['class']->nodeValue == "ql-align-left") {
+                $modifier->setAttribute('align', 'left');
+            } elseif ($node->attributes['class']->nodeValue == "ql-align-right") {
+                $modifier->setAttribute('align', 'right');
             }
         }
         if ($modifier->isBlockModifier()) {

--- a/src/Converters/ParagraphConverter.php
+++ b/src/Converters/ParagraphConverter.php
@@ -20,7 +20,14 @@ class ParagraphConverter implements NodeConverterInterface
         if (isset($node->attributes['align'])) {
             $modifier->setAttribute('align', $node->attributes['align']->value);
         }
-
+        
+        if (isset($node->attributes['class'])) {
+            $class = $node->attributes['class'];
+            $map = ['q-align-center' => 'center', 'q-align-right' => 'right', 'q-align-left' => 'left'];
+            if (isset($map[$class])) {
+                $modifier->setAttribute('align', $map[$class]);
+            }
+        }
         if ($modifier->isBlockModifier()) {
             $ops[] = $modifier;
         }

--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -31,6 +31,7 @@ class HtmlConverter implements HtmlConverterInterface
             new Converters\LinkConverter(),
             new Converters\ParagraphConverter(),
             new Converters\TextConverter(),
+            new Converters\ListConverter(),
         ];
     }
 


### PR DESCRIPTION
Following changes are made keeping in view the Quill JS Requirements
- Added support for `ul` and `ol` tags
- Fixed the `strong` tag
- Added code for `u` or underline tag
- Fixed the `alt` attribute for images
- Fixed the `target` attribute for links
- Added support for Quill JS Class Align center